### PR TITLE
Classroom tutorials

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -4,13 +4,23 @@
 </div>
 <section class="tutorials col md-col-8">
   <% @tutorials.each do |tutorial| %>
-    <div class="tutorial">
-      <img class="thumbnail col md-col-3" src= <%="#{tutorial.thumbnail}" %> >
-      <div class="tutorial-description col md-col-9">
-        <h4 class="tutorial-title-home"><%= link_to tutorial.title, tutorial_path(tutorial), class: "title-link" %> </h4>
-        <p class="description"><%= tutorial.description %></p> <br>
-      </div>
-    </div> <br>
+  <% if !current_user && !tutorial.classroom %>
+<div class="tutorial">
+<img class="thumbnail col md-col-3" src= <%="#{tutorial.thumbnail}" %> >
+<div class="tutorial-description col md-col-9">
+<h4 class="tutorial-title-home"><%= link_to tutorial.title, tutorial_path(tutorial), class: "title-link" %> </h4>
+<p class="description"><%= tutorial.description %></p> <br>
+</div>
+</div> <br>
+<% elsif current_user %>
+<div class="tutorial">
+<img class="thumbnail col md-col-3" src= <%="#{tutorial.thumbnail}" %> >
+<div class="tutorial-description col md-col-9">
+<h4 class="tutorial-title-home"><%= link_to tutorial.title, tutorial_path(tutorial), class: "title-link" %> </h4>
+<p class="description"><%= tutorial.description %></p> <br>
+</div>
+</div> <br>
+<% end %>
   <% end %>
   <hr>
   <br>

--- a/spec/features/vistors/visitor_cannot_see_classroom_content_spec.rb
+++ b/spec/features/vistors/visitor_cannot_see_classroom_content_spec.rb
@@ -20,7 +20,24 @@ describe 'visitor visits video show page' do
         expect(page).to_not have_content(tutorial2.description)
     end
   end
-end 
+
+  it 'I can see all tutorials if logged in' do
+     tutorial1 = create(:tutorial)
+     tutorial2 = create(:tutorial, classroom: true)
+     user = create(:user)
+     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+     visit root_path
+
+     within(first('.tutorials')) do
+       expect(page).to have_content(tutorial1.title)
+       expect(page).to have_content(tutorial1.description)
+
+       expect(page).to have_content(tutorial2.title)
+       expect(page).to have_content(tutorial2.description)
+    end
+  end
+end
 # Currently all tutorials are visible to anyone.
 # We want to make tutorials marked as "classroom content" viewable
 # only if the user is logged in.

--- a/spec/features/vistors/visitor_cannot_see_classroom_content_spec.rb
+++ b/spec/features/vistors/visitor_cannot_see_classroom_content_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe 'visitor visits video show page' do
+  it 'Cannot see tutorials labeled classroom content' do
+    tutorial1 = create(:tutorial)
+    tutorial2 = create(:tutorial, description: "Amazing Much Learning!", classroom: true)
+
+      # video1 = create(:video, tutorial_id: tutorial1.id)
+      # video2 = create(:video, tutorial_id: tutorial1.id)
+      # video3 = create(:video, tutorial_id: tutorial2.id)
+      # video4 = create(:video, tutorial_id: tutorial2.id)
+
+      visit root_path
+
+      within(first('.tutorials')) do
+        expect(page).to have_content(tutorial1.title)
+        expect(page).to have_content(tutorial1.description)
+
+        expect(page).to_not have_content(tutorial2.title)
+        expect(page).to_not have_content(tutorial2.description)
+    end
+  end
+end 
+# Currently all tutorials are visible to anyone.
+# We want to make tutorials marked as "classroom content" viewable
+# only if the user is logged in.
+#
+# The tutorials table has a boolean column for
+# classroom that should be used for this story.


### PR DESCRIPTION
Hide 'classroom content' from non-logged in users. #7 
- Created a test for making visitor cannot see tutorials labeled classroom content from the home page. 
- Updated Welcome/index_html.erb to add logic for the above 
_ Updated test to make sure tutorials labeled as classroom content were visible from the homepage once a user had logged in.