### PR TITLE
Oauth refactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem 'active_model_serializers'
 gem 'omniauth-google-oauth2'
 gem 'will_paginate'
 gem 'acts-as-taggable-on', '~> 6.0'
-gem 'omniauth-census', git: "https://github.com/turingschool-projects/omniauth-census"
 gem 'omniauth-github', github: 'omniauth/omniauth-github', branch: 'master'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,13 +7,6 @@ GIT
       omniauth (~> 1.5)
       omniauth-oauth2 (>= 1.4.0, < 2.0)
 
-GIT
-  remote: https://github.com/turingschool-projects/omniauth-census
-  revision: 2509bcda18ad13d7544b45fa238e03d9d2db1472
-  specs:
-    omniauth-census (0.1.13)
-      omniauth-oauth2 (~> 1.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -395,7 +388,6 @@ DEPENDENCIES
   jquery
   launchy
   listen (>= 3.0.5, < 3.2)
-  omniauth-census!
   omniauth-github!
   omniauth-google-oauth2
   pg (>= 0.18, < 2.0)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,7 +16,8 @@ class SessionsController < ApplicationController
 
   def update
     auth_hash = request.env['omniauth.auth']
-    current_user.update(github_token: auth_hash[:credentials][:token])
+    token = auth_hash[:credentials][:token]
+    current_user.update(github_token: token)
     redirect_to dashboard_path
   end
 
@@ -24,17 +25,4 @@ class SessionsController < ApplicationController
     session[:user_id] = nil
     redirect_to root_path
   end
-
-  private
-  # def auth_hash
-  #   request.env['omniauth.auth']
-  # end
 end
-
-
-
-# class SessionsController < ApplicationController
-# def create
-# auth = request.env["omniauth.auth"]
-#  user = User.find_by_provider_and_uid(auth["provider"], auth["uid"]) || User.create_with_omniauth(auth)     session[:user_id] = user.id     redirect_to root_url, :notice => "Signed in!"
-#   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,17 +2,10 @@ class UsersController < ApplicationController
 
   def show
     if !current_user.github_token.nil?
-      search_results = SearchResults.new
-      @repos = search_results.repos(current_user.github_token)
-      @followers = search_results.followers(current_user.github_token)
-      @followings = search_results.followings(current_user.github_token)
-      # conn = Faraday.new("https://api.github.com")
-      # response = conn.get("/user/repos?access_token=#{current_user.github_token}")
-      #
-      # json = JSON.parse(response.body, symbolize_names: true)
-      # @repos = json[0..4].map do |user_data|
-      #   Repo.new(user_data)
-      # end
+      search_results = SearchResults.new(current_user.github_token)
+      @repos = search_results.repos
+      @followers = search_results.followers
+      @followings = search_results.followings
     end
   end
 
@@ -37,8 +30,3 @@ class UsersController < ApplicationController
     params.require(:user).permit(:email, :first_name, :last_name, :password)
   end
 end
-
-# conn = Faraday.new("https://api.github.com") do |req|
-#       req.headers['Authorization'] = "token #{ENV["GITHUB_ACCESS_TOKEN"]}"
-#     end
-# response = conn.get("/user/repos")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   has_many :videos, through: :user_videos
 
   validates :email, uniqueness: true, presence: true
-  validates :password, presence: true
+  validates :password_digest, presence: true
   validates :first_name, presence: true
 
   enum role: { default: 0, admin: 1}

--- a/app/poros/search_results.rb
+++ b/app/poros/search_results.rb
@@ -1,22 +1,30 @@
 class SearchResults
 
-  def repos(token)
-    json = GithubService.new.list_repos(token)
-    @repos = json[0..4].map do |user_data|
+  def initialize(token)
+    @token = token
+  end
+
+  def github_service(token)
+    GithubService.new(@token)
+  end
+
+  def repos
+    data = github_service(@token).list_repos
+    @repos = data[0..4].map do |user_data|
      Repo.new(user_data)
     end
   end
 
-  def followers(token)
-    json = GithubService.new.list_followers(token)
-    @followers = json.map do |user_data|
+  def followers
+  data = github_service(@token).list_followers
+    @followers = data.map do |user_data|
       Follower.new(user_data)
     end
   end
 
-  def followings(token)
-    json = GithubService.new.list_followings(token)
-    @followings = json.map do |user_data|
+  def followings
+    data = github_service(@token).list_followings
+    @followings = data.map do |user_data|
       Following.new(user_data)
     end
   end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,30 +1,32 @@
 class GithubService
 
-  def list_repos(token)
-    get_url("repos")
-    # response = conn.get("/user/repos?access_token=#{ENV['GITHUB_ACCESS_TOKEN']}")
-    # json = JSON.parse(response.body, symbolize_names: true)
+  def initialize(token)
+    @token = token
   end
 
-  def list_followers(token)
+  def list_repos
+    get_url("repos")
+  end
+
+  def list_followers
     get_url("followers")
   end
 
-  def list_followings(token)
+  def list_followings
     get_url("following")
   end
 
   private
 
   def get_url(url)
-    response = conn.get("/user/#{url}?access_token=#{ENV['GITHUB_ACCESS_TOKEN']}")
+    response = conn.get("/user/#{url}")
     JSON.parse(response.body, symbolize_names: true)
   end
 
   def conn
     Faraday.new("https://api.github.com") do |req|
       req.adapter Faraday.default_adapter
-      req.params[:key] = ENV['GITHUB_ACCESS_TOKEN']
+      req.headers["Authorization"] = "token #{@token}"
     end
   end
 end


### PR DESCRIPTION
- OAuth refactor
- replaces all env[github token] with the github token from current user
- change validation password to password_digest
- only down side is that user must be logged out of github for them to login using github so we may need to change the path but for now, it works